### PR TITLE
Update auth.php to support new wp 6.8 hashs

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -135,12 +135,16 @@ class auth_plugin_authwordpress extends DokuWiki_Auth_Plugin
         if ($data === false) {
             return false;
         }
-
-        $hasher = new PasswordHash(8, true);
-
-        // Add slashes to match WordPress behavior
-        $check = $hasher->CheckPassword(addslashes($pass), $data['pass']);
-        $this->logDebug("Password " . ($check ? 'OK' : 'Invalid'));
+        // check if new type of hash
+        if(str_starts_with( $data['pass'], '$wp' )){
+                $password_to_verify = base64_encode( hash_hmac( 'sha384', $pass, 'wp-sha384', true ) );
+                $check              = password_verify( $password_to_verify, substr( $data['pass'], 3 ) );
+        }else{
+            $hasher = new PasswordHash(8, true);
+            // Add slashes to match WordPress behavior
+            $check = $hasher->CheckPassword(addslashes($pass), $data['pass']);
+        }
+            $this->logDebug("Password " . ($check ? 'OK' : 'Invalid'));
 
         return $check;
     }


### PR DESCRIPTION
I  just did  a small fix for the checkPass function in auth.php, to make it work with Wordpress 6.8 and their new hashing technique. The function is mostly copied directly form the wordpress code  (https://github.com/WordPress/wordpress-develop/blob/9063e30f6f34d313ecdc3394f45ca63283732b24/src/wp-includes/pluggable.php#L2753-L2756). 

